### PR TITLE
var is deprecated in php 5.3 and this car is not used anywhere (was used 

### DIFF
--- a/generator_templates/controller.php
+++ b/generator_templates/controller.php
@@ -3,8 +3,6 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 class [[[GENERATOR_REPLACE_CLASSNAME]]] extends BlockController {
 	
-	var $pobj;
-
 	protected $btName = '[[[GENERATOR_REPLACE_NAME]]]';
 	protected $btDescription = '[[[GENERATOR_REPLACE_DESCRIPTION]]]';
 	protected $btTable = '[[[GENERATOR_REPLACE_TABLENAME]]]';


### PR DESCRIPTION
var is deprecated in php 5.3 and this car is not used anywhere (was used in an earlier version of c5)
